### PR TITLE
Add delay to main loop

### DIFF
--- a/WiFiRelays.ino
+++ b/WiFiRelays.ino
@@ -94,4 +94,5 @@ void setup(void)
 void loop(void)
 {
     server.handleClient();
+    delay(1);
 }


### PR DESCRIPTION
Adding a 1ms delay in the main loop allow to lower the power consumption drastically while maintaining the server response time as explained here: https://www.tablix.org/~avian/blog/archives/2022/08/saving_power_on_an_esp8266_web_server_using_delays/